### PR TITLE
fix: tailwindcss 4

### DIFF
--- a/resources/views/bluesky-comments-alpine.antlers.html
+++ b/resources/views/bluesky-comments-alpine.antlers.html
@@ -4,7 +4,7 @@
 
         Alpine.directive('bluesky-comment', (el, { value, modifiers, expression }, { Alpine, effect, evaluate, evaluateLater, cleanup }) => {
 
-            let template = `<div class="space-y-2 text-sm">
+            let template = `<div class="flex flex-col gap-y-2 text-sm">
 
                 <a :href="'https://bsky.app/profile/' + author.did"
                     class="flex items-center gap-x-2 hover:underline"
@@ -23,11 +23,11 @@
                 <div>
                     <a :href="link"
                        target="_blank"
-                       class="inline-block whitespace-pre-line"
+                       class="pl-7 inline-block whitespace-pre-line"
                        x-text="comment.post.record.text"></a>
                 </div>
 
-                <div class="flex items-center gap-4">
+                <div class="pl-7 flex items-center gap-4">
                     <a :href="link"
                        target="_blank"
                        class="flex items-center gap-x-1">
@@ -57,8 +57,8 @@
                 </div>
 
                 <template x-if="comment.replies && comment.replies.length > 0">
-                    <div class="border-l border-gray-300 py-1 ml-1.5 pl-2">
-                        <div class="mt-2 space-y-6">
+                    <div class="border-l border-gray-300 py-1 ml-2.5 pl-2.5">
+                        <div class="my-1 flex flex-col gap-y-6">
                             <template x-for="(comment, index) in comment.replies" :key="index">
                                 <div x-bluesky-comment></div>
                             </template>

--- a/resources/views/bluesky-comments-alpine.antlers.html
+++ b/resources/views/bluesky-comments-alpine.antlers.html
@@ -58,7 +58,7 @@
 
                 <template x-if="comment.replies && comment.replies.length > 0">
                     <div class="border-l border-gray-300 py-1 ml-1.5 pl-2">
-                        <div class="-mt-4 space-y-6">
+                        <div class="mt-2 space-y-6">
                             <template x-for="(comment, index) in comment.replies" :key="index">
                                 <div x-bluesky-comment></div>
                             </template>

--- a/resources/views/bluesky-comments.antlers.html
+++ b/resources/views/bluesky-comments.antlers.html
@@ -38,10 +38,10 @@
             Reply on Bluesky</a> to join the conversation.
     </p>
 
-    <hr class="mt-6"/>
+    <hr class="my-6"/>
 
     <template x-if="!loading && replies.length">
-        <div class=" space-y-6">
+        <div class="space-y-6">
             <template x-for="(comment, index) in replies" :key="index">
                 <div x-bluesky-comment></div>
             </template>

--- a/resources/views/bluesky-comments.antlers.html
+++ b/resources/views/bluesky-comments.antlers.html
@@ -41,17 +41,17 @@
     <hr class="my-6"/>
 
     <template x-if="!loading && replies.length">
-        <div class="space-y-6">
+        <div class="mt-6 flex flex-col gap-y-4">
             <template x-for="(comment, index) in replies" :key="index">
                 <div x-bluesky-comment></div>
             </template>
 
             <template x-if="hasMoreReplies">
-            <button @click.prevent="showMore"
-                    :disabled="!hasMoreReplies"
-                    class="mt-2 text-sm text-blue-500 underline">
-                Show more comments
-            </button>
+                <button @click.prevent="showMore"
+                        :disabled="!hasMoreReplies"
+                        class="mt-2 text-sm text-blue-500 underline">
+                    Show more comments
+                </button>
             </template>
         </div>
     </template>


### PR DESCRIPTION
Hey, I noticed a bug when upgrading to TailwindCSS v4

I'm not sure what the cause of the problem is, maybe this? 
https://tailwindcss.com/docs/upgrade-guide#space-between-selector

Anyway, this change fixes it in v4. If anyone has a Tailwind CSS 3 project to test it, that would be cool.

---

<img width="45%" alt="Capture d’écran 2025-03-03 à 17 30 37" src="https://github.com/user-attachments/assets/26ff8d24-94fa-4be6-91ee-3d5aac5cd92f" /><img width="45%" alt="Capture d’écran 2025-03-03 à 17 37 59" src="https://github.com/user-attachments/assets/c27d18da-e77f-43ce-9650-c37e980571be" />